### PR TITLE
feat: add tax summary page for income PDFs

### DIFF
--- a/docs/tax-summary.html
+++ b/docs/tax-summary.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>確定申告集計ツール</title>
+<style>
+  body {
+    font-family: Arial, sans-serif;
+    margin: 2rem;
+  }
+  label, input, button {
+    display: block;
+    margin-bottom: 1rem;
+  }
+  table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1rem;
+  }
+  th, td {
+    border: 1px solid #ccc;
+    padding: 0.5rem;
+    text-align: left;
+  }
+  th {
+    background-color: #f5f5f5;
+  }
+</style>
+</head>
+<body>
+<h1>確定申告集計ツール</h1>
+<label>メイン病院の収入PDF<input type="file" id="mainPdf" accept="application/pdf"></label>
+<label>外勤先の収入PDF<input type="file" id="externalPdf" accept="application/pdf"></label>
+<label>バイト病院の収入PDF<input type="file" id="partPdf" accept="application/pdf"></label>
+<label>控除額<input type="number" id="deduction" value="0"></label>
+<button id="calc">集計</button>
+<div id="results"></div>
+<button id="download" style="display:none">CSVダウンロード</button>
+<script type="module">
+import { getDocument } from 'https://cdnjs.cloudflare.com/ajax/libs/pdf.js/3.9.179/pdf.min.mjs';
+
+async function extractNumber(file) {
+  const arrayBuffer = await file.arrayBuffer();
+  const pdf = await getDocument({ data: arrayBuffer }).promise;
+  let text = '';
+  for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+    const page = await pdf.getPage(pageNum);
+    const content = await page.getTextContent();
+    text += content.items.map(i => i.str).join(' ');
+  }
+  const numbers = Array.from(text.matchAll(/[-+]?\d[\d,]*/g)).map(m => parseInt(m[0].replace(/,/g, ''), 10));
+  return numbers.reduce((sum, n) => sum + n, 0);
+}
+
+document.getElementById('calc').addEventListener('click', async () => {
+  const mainFile = document.getElementById('mainPdf').files[0];
+  const extFile = document.getElementById('externalPdf').files[0];
+  const partFile = document.getElementById('partPdf').files[0];
+  const deduction = parseFloat(document.getElementById('deduction').value) || 0;
+
+  const mainIncome = mainFile ? await extractNumber(mainFile) : 0;
+  const extIncome = extFile ? await extractNumber(extFile) : 0;
+  const partIncome = partFile ? await extractNumber(partFile) : 0;
+  const totalIncome = mainIncome + extIncome + partIncome;
+  const netIncome = totalIncome - deduction;
+
+  const tableHtml = `
+    <table>
+      <tr><th>項目</th><th>金額</th></tr>
+      <tr><td>メイン病院</td><td>${mainIncome}</td></tr>
+      <tr><td>外勤先</td><td>${extIncome}</td></tr>
+      <tr><td>バイト病院</td><td>${partIncome}</td></tr>
+      <tr><td>控除</td><td>${deduction}</td></tr>
+      <tr><th>合計収入</th><th>${totalIncome}</th></tr>
+      <tr><th>課税対象</th><th>${netIncome}</th></tr>
+    </table>`;
+  document.getElementById('results').innerHTML = tableHtml;
+
+  const csv = `項目,金額\nメイン病院,${mainIncome}\n外勤先,${extIncome}\nバイト病院,${partIncome}\n控除,${deduction}\n合計収入,${totalIncome}\n課税対象,${netIncome}\n`;
+  const downloadBtn = document.getElementById('download');
+  downloadBtn.style.display = 'inline-block';
+  downloadBtn.onclick = () => {
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'summary.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create tax summary page with PDF uploads for main, external, and part-time hospitals
- allow deduction input and generate CSV for easy copy/paste

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689fe3f58778832785b12feaffa25071