### PR TITLE
chore: add npm release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,52 @@
+name: Release
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    name: Publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+          cache: npm
+          cache-dependency-path: |
+            package-lock.json
+            codex-cli/package-lock.json
+
+      - name: Install root dependencies
+        run: npm ci
+
+      - name: Install CLI dependencies
+        working-directory: codex-cli
+        run: npm ci
+
+      - name: Run tests
+        working-directory: codex-cli
+        run: |
+          npm test
+          npm run lint
+          npm run typecheck
+
+      - name: Build CLI bundle
+        working-directory: codex-cli
+        run: npm run build
+
+      - name: Publish package
+        working-directory: codex-cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "open-codex",
-  "version": "0.1.30",
+  "version": "0.1.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "open-codex",
-      "version": "0.1.30",
+      "version": "0.1.31",
       "license": "Apache-2.0",
       "dependencies": {
         "@inkjs/ui": "^2.0.0",


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds, tests, and publishes the CLI when a release is created
- synchronize the package-lock version with the published package metadata

## Testing
- npm test *(fails: raw-exec process cleanup flake in the container)*
- npm run lint
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_e_68f42a5138688327b22e57dedefb6b8a